### PR TITLE
Embed shared navigation layout

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
-import Navbar from '@/components/Navbar';
-import Footer from '@/components/Footer';
 import Link from 'next/link';
 import Image from 'next/image';
 
 export default function Contact() {
   return (
     <main className="min-h-screen flex flex-col">
-      <Navbar />
       
       {/* Hero Section */}
       <section className="bg-primary-900 text-white py-12">
@@ -236,7 +233,6 @@ export default function Contact() {
         </div>
       </section>
       
-      <Footer />
     </main>
   );
 }

--- a/src/app/how-it-works/page.tsx
+++ b/src/app/how-it-works/page.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
-import Navbar from '@/components/Navbar';
-import Footer from '@/components/Footer';
 import Link from 'next/link';
 import Image from 'next/image';
 
 export default function HowItWorks() {
   return (
     <main className="min-h-screen flex flex-col">
-      <Navbar />
       
       {/* Hero Section */}
       <section className="bg-primary-900 text-white py-12">
@@ -178,7 +175,6 @@ export default function HowItWorks() {
         </div>
       </section>
       
-      <Footer />
     </main>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import '../app/globals.css';
+import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -30,8 +32,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body className={`${inter.className} pt-20`}>
+        <Navbar />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import Navbar from '@/components/Navbar';
-import Footer from '@/components/Footer';
 import Link from 'next/link';
 import Image from 'next/image';
 
@@ -34,7 +32,6 @@ export default function Locations() {
 
   return (
     <main className="min-h-screen flex flex-col">
-      <Navbar />
       
       {/* Hero Section */}
       <section className="bg-primary-900 text-white py-12">
@@ -121,7 +118,6 @@ export default function Locations() {
         </div>
       </section>
       
-      <Footer />
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import React from 'react';
-import Navbar from '@/components/Navbar';
-import Footer from '@/components/Footer';
 import VinDecoder from '@/components/VinDecoder';
 import Link from 'next/link';
 import Image from 'next/image';
@@ -12,7 +10,6 @@ export default function Home() {
 
   return (
     <main className="min-h-screen flex flex-col">
-      <Navbar />
 
       {/* Hero Section */}
       <section className="hero-section bg-primary-900 text-white">
@@ -39,8 +36,6 @@ export default function Home() {
       </section>
 
       {/* ... rest of the sections remain unchanged ... */}
-
-      <Footer />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- centralize `<Navbar />` and `<Footer />` in the app layout
- remove page-level references to the navbar/footer
- add padding to body so content clears the fixed header

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840723aa11c832499a585ae55c560d8