### PR TITLE
Use env vars for MarketCheck API

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,2 @@
+MARKETCHECK_API_KEY=your-marketcheck-api-key
+MARKETCHECK_API_SECRET=your-marketcheck-api-secret

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ pnpm dev
 bun dev
 ```
 
+### Environment Variables
+
+Create a `.env.local` file in the project root with the following variables so the MarketCheck API can be used:
+
+```bash
+MARKETCHECK_API_KEY=your-marketcheck-api-key
+MARKETCHECK_API_SECRET=your-marketcheck-api-secret
+```
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/src/utils/marketcheck.ts
+++ b/src/utils/marketcheck.ts
@@ -5,8 +5,8 @@ interface MarketCheckConfig {
 }
 
 export const MARKETCHECK_CONFIG: MarketCheckConfig = {
-  apiKey: 'FKuNuPaPLi2RDWHLY7NGuFPnJvx53dS0',
-  apiSecret: '5yxomBGfBvmGpKjJ'
+  apiKey: process.env.MARKETCHECK_API_KEY || '',
+  apiSecret: process.env.MARKETCHECK_API_SECRET || ''
 };
 
 interface VehicleDetails {


### PR DESCRIPTION
## Summary
- read `MARKETCHECK_API_KEY` and `MARKETCHECK_API_SECRET` from the environment
- document required variables in the README
- add `.env.local` example

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68407237bc648324919bfea5bded644d