### PR TITLE
Add hero image overlay

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -54,6 +54,21 @@ body {
   padding: 4rem 0;
 }
 
+/* Utility container for hero image with overlay */
+.hero-image-container {
+  position: relative;
+  overflow: hidden;
+  border-radius: 0.5rem;
+}
+
+.hero-image-container::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  pointer-events: none;
+}
+
 .process-step {
   border-left: 4px solid var(--secondary-color);
   padding-left: 1.5rem;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,13 +25,13 @@ export default function Home() {
                 See What You Qualify For
               </Link>
             </div>
-            <div className="relative h-64 md:h-auto">
-              <Image 
-                src="/images/hero-image-new.png" 
-                alt="Hero image showing woman next to car representing Express Title" 
+            <div className="hero-image-container h-64 md:h-auto">
+              <Image
+                src="/images/hero-image-new.png"
+                alt="Hero image showing woman next to car representing Express Title"
                 width={600}
                 height={400}
-                className="rounded-lg shadow-lg"
+                className="rounded-lg shadow-lg object-cover brightness-75"
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- darken hero image with overlay for improved text contrast
- add brightness utility for hero image

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840723127b48324acb1c8b18dcacae0