### PR TITLE
Fix hero layout with navbar offset

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image';
 
 export default function Contact() {
   return (
-    <main className="min-h-screen flex flex-col">
+    <main className="min-h-screen flex flex-col pt-16">
       <Navbar />
       
       {/* Hero Section */}

--- a/src/app/how-it-works/page.tsx
+++ b/src/app/how-it-works/page.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image';
 
 export default function HowItWorks() {
   return (
-    <main className="min-h-screen flex flex-col">
+    <main className="min-h-screen flex flex-col pt-16">
       <Navbar />
       
       {/* Hero Section */}

--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -33,7 +33,7 @@ export default function Locations() {
   ];
 
   return (
-    <main className="min-h-screen flex flex-col">
+    <main className="min-h-screen flex flex-col pt-16">
       <Navbar />
       
       {/* Hero Section */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
   const [vehicleInfo, setVehicleInfo] = React.useState<any>(null);
 
   return (
-    <main className="min-h-screen flex flex-col">
+    <main className="min-h-screen flex flex-col pt-16">
       <Navbar />
 
       {/* Hero Section */}


### PR DESCRIPTION
## Summary
- add `pt-16` padding so hero images aren't hidden by the fixed Navbar

## Testing
- `npm install`
- `npm run build` *(fails without dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6840722d3508832497182e546bc8077d